### PR TITLE
Updates build with go tip and BUILDARGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 go:
   - 1.11.x
   - 1.12.x
+  - tip
 matrix:
   allow_failures:
     - go: tip


### PR DESCRIPTION
The .travis.yml file has been updated to allow a failing build against the tip of the go github repo.  The Makefile has been updated to to allow BUILDARGS to be supplied and this will allow the vendor directory to be used if needs be.  Default is still to use go modules in the standard sense.